### PR TITLE
correct the 12 hour time format in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git clone https://github.com/eouia/worldclock # clone this repository
   config: {
     // See 'Configuration options' for more information.
 
-    timeFormat: 'HH:mm A', //defined in moment.js format()
+    timeFormat: 'hh:mm A', //defined in moment.js format()
     style: 'top', //predefined 4 styles; 'top', 'left','right','bottom'
     offsetTimezone: null, // Or you can set `Europe/Berlin` to get timegap difference from this timezone. `null` will be UTC timegap.
     clocks: [


### PR DESCRIPTION
in moment.js `hh` is used to show 12 hour time, `HH` is used to show the 24 hour time

so for the default config, `hh:mm A` is the correct format for show the `11:30 PM`